### PR TITLE
fixed static port 801

### DIFF
--- a/example/test.go
+++ b/example/test.go
@@ -28,10 +28,11 @@ func main() {
 	debug := flag.Bool("debug", false, "print debugging messages.")
 	ip := flag.String("ip", "172.16.21.10", "the address to the AMS router")
 	netid := flag.String("netid", "172.16.21.10.1.1", "AMS NetID of the target")
-	port := flag.Int("port", 801, "AMS Port of the target")
+	intport := flag.Uint("port", 801, "AMS Port of the target")
 
 	flag.Parse()
-	fmt.Println(*debug, *ip, *netid, *port) /*}}}*/
+	port := uint16(*intport)
+	fmt.Println(*debug, *ip, *netid, port) /*}}}*/
 
 	// Start the logger/*{{{*/
 	logger, err := log.LoggerFromConfigAsFile("logconfig.xml")
@@ -41,7 +42,7 @@ func main() {
 	log.ReplaceLogger(logger)
 	goADS.UseLogger(logger) /*}}}*/
 	// Startup the connection/*{{{*/
-	connection, e := goADS.NewConnection(*ip, *netid, *port)
+	connection, e := goADS.NewConnection(*ip, *netid, port)
 	connection.Connect()
 	defer connection.Close() // Close the connection when we are done
 	if e != nil {

--- a/main.go
+++ b/main.go
@@ -78,7 +78,7 @@ func (conn *Connection) Connect() {
 	conn.shutdownFinal = make(chan bool)
 
 	conn.target = stringToNetId(conn.netid)
-	conn.target.port = 801
+	conn.target.port = conn.port
 
 	localhost, _, _ := net.SplitHostPort(conn.connection.LocalAddr().String())
 	conn.source = stringToNetId(localhost)


### PR DESCRIPTION
Currently the port 801 is fixed and cannot be changed.
This is problematic especially because TwinCAT3 uses port 851 per default for PLC.
Beside that I also used uint16 for port variable because this is sufficient.